### PR TITLE
Add base price and date fields to clients

### DIFF
--- a/agregar_campos_clientes.sql
+++ b/agregar_campos_clientes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE clientes ADD COLUMN precio_base DECIMAL(10,2) DEFAULT NULL AFTER email;
+ALTER TABLE clientes ADD COLUMN fecha_base DATE DEFAULT NULL AFTER precio_base;

--- a/ajaxClientes.php
+++ b/ajaxClientes.php
@@ -13,7 +13,7 @@ if(!empty($_GET["id_modalidad"]&& $_GET["id_modalidad"] != 0)) {
 
 //Ventas
 $pdo = Database::connect();
-$sql = "SELECT id AS id_cliente, razon_social, cuit, direccion, telefono, email FROM clientes WHERE 1";
+$sql = "SELECT id AS id_cliente, razon_social, cuit, direccion, telefono, email, precio_base, fecha_base FROM clientes WHERE 1";
 //echo $sql;
 foreach ($pdo->query($sql) as $row) {
 
@@ -28,6 +28,7 @@ foreach ($pdo->query($sql) as $row) {
     "direccion"=>$row["direccion"],
     "email"=>$row["email"],
     "telefono"=>$row["telefono"],
+    "precio_base"=>$row["precio_base"],
     "acciones" => $btnModificar.$btnEliminar.$btnVer
   ];
 }

--- a/facturacion.sql
+++ b/facturacion.sql
@@ -34,6 +34,8 @@ CREATE TABLE `clientes` (
   `direccion` varchar(255) DEFAULT NULL,
   `telefono` varchar(20) DEFAULT NULL,
   `email` varchar(100) DEFAULT NULL,
+  `precio_base` decimal(10,2) DEFAULT NULL,
+  `fecha_base` date DEFAULT NULL,
   `id_usuario` int(11) DEFAULT NULL,
   `fecha_hora_alta` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/listarClientes.php
+++ b/listarClientes.php
@@ -98,6 +98,7 @@ include("database.php");?>
                             <th>E-Mail</th>
                             <th>Teléfono</th>
                             <th>Direccion</th>
+                            <th>Precio Base</th>
                             <th>Opciones</th>
                           </tr>
                         </thead>
@@ -222,6 +223,7 @@ include("database.php");?>
             {"data": "email"},
             {"data": "telefono"},
             {"data": "direccion"},
+            {"data": "precio_base"},
             {"data": "acciones"},
           ],
           drawCallback: function(settings, json){

--- a/modificarCliente.php
+++ b/modificarCliente.php
@@ -16,14 +16,25 @@ if ( null==$id ) {
 }
 
 if ( !empty($_POST)) {
-  
+
   // insert data
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  
-  $sql = "UPDATE clientes set razon_social = ?, cuit = ?, email = ?, telefono = ?, direccion = ? where id = ?";
+  $precio_base = filter_input(INPUT_POST, 'precio_base', FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+  $fecha_base = filter_input(INPUT_POST, 'fecha_base', FILTER_SANITIZE_STRING);
+
+  $sql = "UPDATE clientes set razon_social = ?, cuit = ?, email = ?, telefono = ?, direccion = ?, precio_base = ?, fecha_base = ? where id = ?";
   $q = $pdo->prepare($sql);
-  $q->execute(array($_POST['razon_social'],$_POST['cuit'],$_POST['email'],$_POST['telefono'],$_POST['direccion'],$_GET['id']));
+  $q->execute(array(
+    $_POST['razon_social'],
+    $_POST['cuit'],
+    $_POST['email'],
+    $_POST['telefono'],
+    $_POST['direccion'],
+    $precio_base,
+    $fecha_base,
+    $_GET['id']
+  ));
   
   Database::disconnect();
   
@@ -33,7 +44,7 @@ if ( !empty($_POST)) {
   
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  $sql = "SELECT id, razon_social, cuit, email, telefono, direccion FROM clientes WHERE id = ? ";
+  $sql = "SELECT id, razon_social, cuit, email, telefono, direccion, precio_base, fecha_base FROM clientes WHERE id = ? ";
   $q = $pdo->prepare($sql);
   $q->execute(array($id));
   $data = $q->fetch(PDO::FETCH_ASSOC);
@@ -113,6 +124,14 @@ if ( !empty($_POST)) {
                           <div class="form-group row">
                             <label class="col-sm-3 col-form-label">E-mail</label>
                             <div class="col-sm-9"><input name="email" type="text" maxlength="99" class="form-control" value="<?=$data['email']?>"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Precio Base</label>
+                            <div class="col-sm-9"><input name="precio_base" type="number" step="0.01" class="form-control" value="<?=$data['precio_base']?>"></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Fecha Base</label>
+                            <div class="col-sm-9"><input name="fecha_base" type="date" class="form-control" value="<?=$data['fecha_base']?>"></div>
                           </div>
                         </div>
                       </div>

--- a/nuevoCliente.php
+++ b/nuevoCliente.php
@@ -6,14 +6,25 @@ if(empty($_SESSION['user'])){
 }
 require 'database.php';
 if ( !empty($_POST)) {
-  
+
   // insert data
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  
-  $sql = "INSERT INTO clientes (razon_social,cuit,direccion,telefono,email,id_usuario) VALUES (?,?,?,?,?,?)";
+  $precio_base = filter_input(INPUT_POST, 'precio_base', FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+  $fecha_base = filter_input(INPUT_POST, 'fecha_base', FILTER_SANITIZE_STRING);
+
+  $sql = "INSERT INTO clientes (razon_social,cuit,direccion,telefono,email,precio_base,fecha_base,id_usuario) VALUES (?,?,?,?,?,?,?,?)";
   $q = $pdo->prepare($sql);
-  $q->execute(array($_POST['razon_social'],$_POST['cuit'],$_POST['direccion'],$_POST['telefono'],$_POST['email'],$_SESSION["user"]['id']));
+  $q->execute(array(
+    $_POST['razon_social'],
+    $_POST['cuit'],
+    $_POST['direccion'],
+    $_POST['telefono'],
+    $_POST['email'],
+    $precio_base,
+    $fecha_base,
+    $_SESSION["user"]['id']
+  ));
   
   Database::disconnect();
   
@@ -92,6 +103,14 @@ if ( !empty($_POST)) {
                           <div class="form-group row">
                             <label class="col-sm-3 col-form-label">E-mail</label>
                             <div class="col-sm-9"><input name="email" type="text" maxlength="99" class="form-control" value=""></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Precio Base</label>
+                            <div class="col-sm-9"><input name="precio_base" type="number" step="0.01" class="form-control" value=""></div>
+                          </div>
+                          <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Fecha Base</label>
+                            <div class="col-sm-9"><input name="fecha_base" type="date" class="form-control" value=""></div>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- add `precio_base` and `fecha_base` columns in SQL schema for clientes
- expose fields in client create and edit forms and list `precio_base`
- include SQL patch to alter existing tables

## Testing
- `php -l nuevoCliente.php`
- `php -l modificarCliente.php`
- `php -l listarClientes.php`
- `php -l ajaxClientes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8be859dc88321834869673c0f2209