### PR TITLE
Add CLI script to recalc client prices

### DIFF
--- a/agregar_campos_clientes.sql
+++ b/agregar_campos_clientes.sql
@@ -1,2 +1,3 @@
 ALTER TABLE clientes ADD COLUMN precio_base DECIMAL(10,2) DEFAULT NULL AFTER email;
 ALTER TABLE clientes ADD COLUMN fecha_base DATE DEFAULT NULL AFTER precio_base;
+ALTER TABLE clientes ADD COLUMN precio_actual DECIMAL(10,2) DEFAULT NULL AFTER fecha_base;

--- a/facturacion.sql
+++ b/facturacion.sql
@@ -36,6 +36,7 @@ CREATE TABLE `clientes` (
   `email` varchar(100) DEFAULT NULL,
   `precio_base` decimal(10,2) DEFAULT NULL,
   `fecha_base` date DEFAULT NULL,
+  `precio_actual` decimal(10,2) DEFAULT NULL,
   `id_usuario` int(11) DEFAULT NULL,
   `fecha_hora_alta` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/recalcularTarifas.php
+++ b/recalcularTarifas.php
@@ -1,0 +1,44 @@
+<?php
+require 'database.php';
+
+try {
+    $pdo = Database::connect();
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    // Obtener clientes con precio base y fecha base definidos
+    $sql = "SELECT id, razon_social, precio_base, fecha_base FROM clientes WHERE precio_base IS NOT NULL AND fecha_base IS NOT NULL";
+    foreach ($pdo->query($sql) as $cliente) {
+        $precio_base = (float)$cliente['precio_base'];
+        $fecha_base = $cliente['fecha_base'];
+        $factor = 1.0;
+        $fecha_inicio = new DateTime($fecha_base);
+        $fecha_fin = new DateTime(); // Fecha actual
+
+        if ($fecha_fin > $fecha_inicio) {
+            $fecha_inicio->modify('first day of next month');
+            while ($fecha_inicio <= $fecha_fin) {
+                $anio = (int)$fecha_inicio->format('Y');
+                $mes = (int)$fecha_inicio->format('n');
+                $q = $pdo->prepare('SELECT porcentaje FROM ipc_historial WHERE anio=? AND mes=?');
+                $q->execute(array($anio, $mes));
+                $ipc = $q->fetch(PDO::FETCH_ASSOC);
+                if ($ipc) {
+                    $factor *= (1 + $ipc['porcentaje']/100);
+                }
+                $fecha_inicio->modify('first day of next month');
+            }
+        }
+
+        $precio_actual = round($precio_base * $factor, 2);
+        $u = $pdo->prepare('UPDATE clientes SET precio_actual = ? WHERE id = ?');
+        $u->execute(array($precio_actual, $cliente['id']));
+
+        $message = sprintf("Cliente %s (ID %d) actualizado: %.2f\n", $cliente['razon_social'], $cliente['id'], $precio_actual);
+        echo $message;
+        file_put_contents('save_log.txt', $message, FILE_APPEND);
+    }
+
+    Database::disconnect();
+} catch (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . "\n";
+}


### PR DESCRIPTION
## Summary
- add `recalcularTarifas.php` CLI script to update clients' current price using IPC data
- add `precio_actual` field to `clientes` table and provide SQL alteration

## Testing
- `php -l recalcularTarifas.php`
- `php recalcularTarifas.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d708b4a08321a43c895fc9f39ff6