### PR TITLE
Refactor IPC period handling

### DIFF
--- a/facturacion.sql
+++ b/facturacion.sql
@@ -115,8 +115,7 @@ CREATE TABLE `usuarios` (
 
 CREATE TABLE `ipc_historial` (
   `id` int(11) NOT NULL,
-  `anio` int(11) NOT NULL,
-  `mes` int(11) NOT NULL,
+  `periodo` date NOT NULL,
   `porcentaje` decimal(10,2) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/getPrecioUnitario.php
+++ b/getPrecioUnitario.php
@@ -16,10 +16,9 @@ if(!empty($_GET['id_cliente']) && !empty($_GET['fecha_factura'])) {
     if($fecha_fin > $fecha_inicio){
       $fecha_inicio->modify('first day of next month');
       while($fecha_inicio <= $fecha_fin){
-        $anio = (int)$fecha_inicio->format('Y');
-        $mes = (int)$fecha_inicio->format('n');
-        $q2 = $pdo->prepare("SELECT porcentaje FROM ipc_historial WHERE anio=? AND mes=?");
-        $q2->execute(array($anio, $mes));
+        $periodo = $fecha_inicio->format('Y-m-01');
+        $q2 = $pdo->prepare("SELECT porcentaje FROM ipc_historial WHERE periodo = ?");
+        $q2->execute(array($periodo));
         $ipc = $q2->fetch(PDO::FETCH_ASSOC);
         if($ipc){
           $factor *= (1 + $ipc['porcentaje']/100);

--- a/listarIPC.php
+++ b/listarIPC.php
@@ -45,7 +45,7 @@ if(empty($_SESSION['user'])){
                         <tbody><?php
                           include 'database.php';
                           $pdo = Database::connect();
-                          $sql = " SELECT id, anio, mes, porcentaje FROM ipc_historial ORDER BY anio DESC, mes DESC";
+                          $sql = " SELECT id, DATE_FORMAT(periodo,'%Y') AS anio, DATE_FORMAT(periodo,'%m') AS mes, porcentaje FROM ipc_historial ORDER BY periodo DESC";
                           foreach ($pdo->query($sql) as $row) {?>
                             <tr>
                               <td><?=$row["id"]?></td>

--- a/nuevoIPC.php
+++ b/nuevoIPC.php
@@ -12,21 +12,24 @@ if (!empty($_GET['id'])) {
 }
 
 if (!empty($_POST)) {
-  $anio = $_POST['anio'];
-  $mes = $_POST['mes'];
+  $periodo = $_POST['periodo'];
+  // Guardar como primer día del mes
+  if ($periodo && strlen($periodo) == 7) {
+    $periodo .= '-01';
+  }
   $porcentaje = $_POST['porcentaje'];
 
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
   if ($id) {
-    $sql = "UPDATE ipc_historial SET anio=?, mes=?, porcentaje=? WHERE id=?";
+    $sql = "UPDATE ipc_historial SET periodo=?, porcentaje=? WHERE id=?";
     $q = $pdo->prepare($sql);
-    $q->execute(array($anio, $mes, $porcentaje, $id));
+    $q->execute(array($periodo, $porcentaje, $id));
   } else {
-    $sql = "INSERT INTO ipc_historial (anio,mes,porcentaje) VALUES (?,?,?)";
+    $sql = "INSERT INTO ipc_historial (periodo,porcentaje) VALUES (?,?)";
     $q = $pdo->prepare($sql);
-    $q->execute(array($anio, $mes, $porcentaje));
+    $q->execute(array($periodo, $porcentaje));
   }
   Database::disconnect();
   header("Location: listarIPC.php");
@@ -39,13 +42,11 @@ if ($id) {
   $q = $pdo->prepare($sql);
   $q->execute(array($id));
   $data = $q->fetch(PDO::FETCH_ASSOC);
-  $anio = $data['anio'];
-  $mes = $data['mes'];
+  $periodo = substr($data['periodo'],0,7);
   $porcentaje = $data['porcentaje'];
   Database::disconnect();
 } else {
-  $anio = '';
-  $mes = '';
+  $periodo = '';
   $porcentaje = '';
 }
 ?>
@@ -79,12 +80,8 @@ if ($id) {
                       <div class="row">
                         <div class="col">
                           <div class="form-group row">
-                            <label class="col-sm-3 col-form-label">Año</label>
-                            <div class="col-sm-9"><input name="anio" type="number" class="form-control" value="<?=$anio;?>" required></div>
-                          </div>
-                          <div class="form-group row">
-                            <label class="col-sm-3 col-form-label">Mes</label>
-                            <div class="col-sm-9"><input name="mes" type="number" min="1" max="12" class="form-control" value="<?=$mes;?>" required></div>
+                            <label class="col-sm-3 col-form-label">Periodo</label>
+                            <div class="col-sm-9"><input name="periodo" type="month" class="form-control" value="<?=$periodo;?>" required></div>
                           </div>
                           <div class="form-group row">
                             <label class="col-sm-3 col-form-label">Porcentaje</label>

--- a/recalcularTarifas.php
+++ b/recalcularTarifas.php
@@ -17,10 +17,9 @@ try {
         if ($fecha_fin > $fecha_inicio) {
             $fecha_inicio->modify('first day of next month');
             while ($fecha_inicio <= $fecha_fin) {
-                $anio = (int)$fecha_inicio->format('Y');
-                $mes = (int)$fecha_inicio->format('n');
-                $q = $pdo->prepare('SELECT porcentaje FROM ipc_historial WHERE anio=? AND mes=?');
-                $q->execute(array($anio, $mes));
+                $periodo = $fecha_inicio->format('Y-m-01');
+                $q = $pdo->prepare('SELECT porcentaje FROM ipc_historial WHERE periodo = ?');
+                $q->execute(array($periodo));
                 $ipc = $q->fetch(PDO::FETCH_ASSOC);
                 if ($ipc) {
                     $factor *= (1 + $ipc['porcentaje']/100);

--- a/reporteIPC.php
+++ b/reporteIPC.php
@@ -19,10 +19,9 @@ function calcularPrecioActual($pdo, $precio_base, $fecha_base, $fecha_fin){
     if($fin > $inicio){
         $inicio->modify('first day of next month');
         while($inicio <= $fin){
-            $anio = (int)$inicio->format('Y');
-            $mes  = (int)$inicio->format('n');
-            $stmt = $pdo->prepare("SELECT porcentaje FROM ipc_historial WHERE anio=? AND mes=?");
-            $stmt->execute([$anio, $mes]);
+            $periodo = $inicio->format('Y-m-01');
+            $stmt = $pdo->prepare("SELECT porcentaje FROM ipc_historial WHERE periodo = ?");
+            $stmt->execute([$periodo]);
             $ipc = $stmt->fetch(PDO::FETCH_ASSOC);
             if($ipc){
                 $factor *= (1 + $ipc['porcentaje']/100);


### PR DESCRIPTION
## Summary
- use `periodo` date field for IPC lookups in tariff recalculation and price unit fetch
- update IPC management forms and listings to work with a single period field
- adjust SQL schema to define `periodo` column in `ipc_historial`

## Testing
- `php -l getPrecioUnitario.php`
- `php -l listarIPC.php`
- `php -l nuevoIPC.php`
- `php -l recalcularTarifas.php`
- `php -l reporteIPC.php`


------
https://chatgpt.com/codex/tasks/task_e_68baeda21bd48321990b4b3de23efa28